### PR TITLE
Declare HTML5 scripts and styles support for better compliance with W3C validator

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -62,6 +62,8 @@ if ( ! function_exists( 'kawi_setup' ) ) :
 			'comment-list',
 			'gallery',
 			'caption',
+			'script',
+			'style',
 		) );
 
 		// Add support for the custom header feature.


### PR DESCRIPTION
Given this theme is written in HTML5, it should declare HTML5 support for styles and script to avoid using `type` attributes in styles and scripts.

This feature was introduced in WordPress 5.3, for reference, see:
- https://make.wordpress.org/core/2019/10/15/miscellaneous-developer-focused-changes-in-5-3/
- https://core.trac.wordpress.org/ticket/42804#comment:32