### PR TITLE
Header: fix conditional statement and improve accessibility

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -14,7 +14,7 @@ function kawi_site_branding() {
 		<div class="site-branding">
 			<?php the_custom_logo(); ?>
 			<div class="site-details">
-				<?php if ( is_front_page() || ( is_front_page() && is_home() ) ) : ?>
+				<?php if ( is_front_page() ) : ?>
 					<h1 class="site-title caps"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" aria-current="page"><?php bloginfo( 'name' ); ?></a></h1>
 				<?php else : ?>
 					<p class="site-title caps"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -14,8 +14,8 @@ function kawi_site_branding() {
 		<div class="site-branding">
 			<?php the_custom_logo(); ?>
 			<div class="site-details">
-				<?php if ( is_front_page() ) : ?>
-					<h1 class="site-title caps"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+				<?php if ( is_front_page() || ( is_front_page() && is_home() ) ) : ?>
+					<h1 class="site-title caps"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" aria-current="page"><?php bloginfo( 'name' ); ?></a></h1>
 				<?php else : ?>
 					<p class="site-title caps"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
 				<?php endif;


### PR DESCRIPTION
Hi Vincent,

This pull request fixes the conditional statement used to display the site logo. Indeed `is_front_page` only works if you're using a page on front, is doesn't work when the blog page is on front.

It also improves the accessibility of the theme by adding an `aria-current` attribute when the homepage is the current page.

Cheers,
Jb